### PR TITLE
Remove scroll animation from small screens

### DIFF
--- a/js/modules/slide-delay.js
+++ b/js/modules/slide-delay.js
@@ -1,6 +1,8 @@
 export function slideDelayAnimation() {
-    gsap.fromTo('.slide-down-delay', {height: 0},
-        {height: '300px', duration: 1, delay: .5, ease: 'power.out',
-            scrollTrigger: {trigger: '.slide-down-delay', start: 'top center'}
-    });
+    if (window.innerWidth >= 412) {
+        gsap.fromTo('.slide-down-delay', {height: 0},
+            {height: '300px', duration: 1, delay: .5, ease: 'power.out',
+                scrollTrigger: {trigger: '.slide-down-delay', start: 'top center'}
+        });
+    }
 }

--- a/js/modules/slide.js
+++ b/js/modules/slide.js
@@ -4,18 +4,20 @@ export function slideAnimation() {
     slideDown = document.querySelectorAll('.slide-down');
 
     gsap.registerPlugin(ScrollTrigger);
-        
-    slideUp.forEach(container => {
-        gsap.fromTo(container, {opacity: 0, y: 50},
-            {opacity: 1, y: 0, duration: 1, ease: 'power.out',
-                scrollTrigger: {trigger: container, start: 'top center'}
-            });
-    });
 
-    slideDown.forEach(container => {
-        gsap.fromTo(container, {opacity: 0, y: -50},
-            {opacity: 1, y: 0, duration: 1, ease: 'power.out',
-                scrollTrigger: {trigger: container, start: 'top center'}
-            });
-    });
+    if (window.innerWidth >= 412) {
+        slideUp.forEach(container => {
+            gsap.fromTo(container, {opacity: 0, y: 50},
+                {opacity: 1, y: 0, duration: 1, ease: 'power.out',
+                    scrollTrigger: {trigger: container, start: 'top center'}
+                });
+        });
+    
+        slideDown.forEach(container => {
+            gsap.fromTo(container, {opacity: 0, y: -50},
+                {opacity: 1, y: 0, duration: 1, ease: 'power.out',
+                    scrollTrigger: {trigger: container, start: 'top center'}
+                });
+        });
+    }
 }


### PR DESCRIPTION
In this commit, scroll trigger animations were removed from smaller screens to prevent bugs.